### PR TITLE
Fix non-whirly monsters seeping through their shirts

### DIFF
--- a/src/worn.c
+++ b/src/worn.c
@@ -904,7 +904,7 @@ boolean polyspot;
         }
         if ((otmp = which_armor(mon, W_ARMC)) != 0) {
             if (vis) {
-                if (is_whirly(mon->data))
+                if (is_whirly(mdat))
                     pline("%s %s falls, unsupported!", s_suffix(Monnam(mon)),
                           cloak_simple_name(otmp));
                 else
@@ -917,7 +917,7 @@ boolean polyspot;
         }
         if ((otmp = which_armor(mon, W_ARMU)) != 0) {
             if (vis) {
-                if (sliparm(mon->data))
+                if (is_whirly(mdat))
                     pline("%s seeps right through %s shirt!", Monnam(mon),
                           ppronoun);
                 else


### PR DESCRIPTION
Minor message bug. Checking sliparm is wrong here because that entire segment of code was already in a clause that had guaranteed sliparm. Assuming this is supposed to be a mirror of the player logic in polyself.c, the case for seeping through one's shirt should be limited to whirly monsters.

The weird message is reproducible by turning on monpolycontrol, getting some monster to pick up and put on a +5 shirt, and polymorphing it into something tiny like a newt that will trigger sliparm but is not whirly.